### PR TITLE
fix(install): Fix `vc-config.json` and `vccl-config.json` installation on Darwin

### DIFF
--- a/VisualCraft/install.cmake
+++ b/VisualCraft/install.cmake
@@ -38,7 +38,7 @@ if(CMAKE_SYSTEM_NAME MATCHES "Darwin")
 
     # Install config json file, VisualCraft will try to find it by ./vc-config.json
     install(FILES vc-config.json
-        DESTINATION ${CMAKE_INSTALL_PREFIX})
+        DESTINATION ${CMAKE_INSTALL_PREFIX}/VisualCraft.app/Contents/MacOS)
 
     # Run macdeployqt at install time
     install(SCRIPT ${CMAKE_CURRENT_BINARY_DIR}/deploy_qt.cmake)

--- a/vccl/install.cmake
+++ b/vccl/install.cmake
@@ -35,7 +35,7 @@ if(CMAKE_SYSTEM_NAME MATCHES "Darwin")
 
     # Install config json file, vccl will try to find it by ./vccl-config.json
     install(FILES vccl-config.json
-        DESTINATION ${CMAKE_INSTALL_PREFIX})
+    DESTINATION ${CMAKE_INSTALL_PREFIX}/vccl.app/Contents/MacOS)
 
     # Run macdeployqt at install time
     install(SCRIPT ${CMAKE_CURRENT_BINARY_DIR}/deploy_qt.cmake)


### PR DESCRIPTION
<!--- IMPORTANT: Fill out all required fields. Otherwise we might close this PR temporarily -->

<!--- IMPORTANT: If this PR addresses multiple unrelated issues, it will be closed until separated. -->

### Description

在 macOS 上，VisualCraft 和 vccl 的 `vc-config.json` 和 `vccl-config.json` 没有被正确的复制到对应的 app 包中并导致报错，该 PR 解决了此问题

<!--- REQUIRED: Describe what changed in detail -->

### Related Issues

<!--- REQUIRED: Tag all related issues (e.g. * #123) -->
<!--- If this PR resolves a bug, please specify (e.g. * fix #123) -->
<!--- If this PR implements a new feature, please specify (e.g. * resolve #123) -->
<!--- If this PR addresses multiple issues, these issues must be related to one other -->

N/A

### Checklist

<!--- Add things that are not yet implemented above -->

- [X] The issues this PR addresses are related to each other
- [X] My code builds and runs on my machine
- [X] My changes are all related to the related issue above
- [X] I documented my code

### Screenshots

<!--- REQUIRED: if issue is UI related -->

<!--- IMPORTANT: Fill out all required fields. Otherwise we might close this PR temporarily -->

N/A
